### PR TITLE
Workaround for issue#51

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (PLATFORM_WINDOWS)
     if(BPF_PERF_LOCAL_NUGET_PATH)
       exec_program(${NUGET} ARGS install "eBPF-for-Windows" -ExcludeVersion -OutputDirectory ${PROJECT_BINARY_DIR}/packages -Source ${BPF_PERF_LOCAL_NUGET_PATH} -NoCache)
     else()
-      exec_program(${NUGET} ARGS install "eBPF-for-Windows" -Version 0.13.0 -ExcludeVersion -OutputDirectory ${PROJECT_BINARY_DIR}/packages)
+      exec_program(${NUGET} ARGS install "eBPF-for-Windows" -Version 0.15.0 -ExcludeVersion -OutputDirectory ${PROJECT_BINARY_DIR}/packages)
     endif()
   endif()
   set(EBPF_LIB "ebpfapi")
@@ -35,19 +35,21 @@ if (PLATFORM_WINDOWS)
   # Run  export_program_info.exe from the eBPF-for-Windows package
   execute_process(COMMAND "${EBPF_BIN_PATH}/export_program_info.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
 
-  # Download the XDP-dev-kit from GitHub
-  file(DOWNLOAD "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0+c10f37fa/xdp-devkit-x64-1.1.0.zip" "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip")
-  # Unzip the XDP-dev-kit
-  # Create folder xdp-devkit
-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
-  # Unzip the xdp-devkit.zip file into the xdp-devkit folder
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip" WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
+  # Issue: https://github.com/microsoft/bpf_performance/issues/51
+  # Skip the XDP-dev-kit download until the issue is resolved.
+  # # Download the XDP-dev-kit from GitHub
+  # file(DOWNLOAD "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0+c10f37fa/xdp-devkit-x64-1.1.0.zip" "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip")
+  # # Unzip the XDP-dev-kit
+  # # Create folder xdp-devkit
+  # file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
+  # # Unzip the xdp-devkit.zip file into the xdp-devkit folder
+  # execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip" WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
 
-  SET(XDP_INC_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/include")
-  SET(XDP_LIB_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/lib")
-  SET(XDP_BIN_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin")
-  # Run xdp_bpfexport.exe from the xdp-dev-kit
-  execute_process(COMMAND "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin/xdp_bpfexport.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
+  # SET(XDP_INC_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/include")
+  # SET(XDP_LIB_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/lib")
+  # SET(XDP_BIN_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin")
+  # # Run xdp_bpfexport.exe from the xdp-dev-kit
+  # execute_process(COMMAND "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin/xdp_bpfexport.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
 elseif(PLATFORM_LINUX)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(LIBBPF REQUIRED libbpf)


### PR DESCRIPTION
This pull request primarily makes changes to the `CMakeLists.txt` file to update the version of the `eBPF-for-Windows` package and temporarily disable the downloading and usage of the `XDP-dev-kit` due to an unresolved issue.

Here are the key changes:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL27-R27): Updated the version of the `eBPF-for-Windows` package from `0.13.0` to `0.15.0` in the `exec_program` command. This is used when the `BPF_PERF_LOCAL_NUGET_PATH` is not set.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL38-R52): The downloading, unzipping, and usage of the `XDP-dev-kit` from GitHub has been commented out. This change is due to a linked issue that needs to be resolved. As a result, the commands to set the `XDP_INC_PATH`, `XDP_LIB_PATH`, and `XDP_BIN_PATH`, and to run `xdp_bpfexport.exe` from the `xdp-dev-kit` have also been commented out.