### PR TITLE
Return XDP_PASS on success not 0

### DIFF
--- a/bpf/bpf.h.inc
+++ b/bpf/bpf.h.inc
@@ -10,6 +10,7 @@
 #if defined(PLATFORM_WINDOWS)
 #include <bpf_helpers.h>
 #include <bpf_endian.h>
+#include <ebpf_nethooks.h>
 #define BPF_F_NO_PREALLOC 0
 #elif defined(PLATFORM_LINUX)
 #include <linux/bpf.h>

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -383,6 +383,7 @@ tests:
     iteration_count: 1000000
     program_type: xdp
     pass_data: true
+    expected_result: 1
     program_cpu_assignment:
       test_bpf_xdp_adjust_head_0: all
 
@@ -392,6 +393,7 @@ tests:
     iteration_count: 1000000
     program_type: xdp
     pass_data: true
+    expected_result: 1
     program_cpu_assignment:
       test_bpf_xdp_adjust_head_plus_100: all
 
@@ -401,6 +403,7 @@ tests:
     iteration_count: 1000000
     program_type: xdp
     pass_data: true
+    expected_result: 1
     program_cpu_assignment:
       test_bpf_xdp_adjust_head_minus_100: all
 

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -3,37 +3,37 @@
 
 #include "bpf.h"
 
-SEC("xdp/baseline") int test_xdp_baseline(void** ctx) { return 0; }
+SEC("xdp/baseline") int test_xdp_baseline(xdp_md_t* ctx) { return XDP_PASS; }
 
 // Test cases for bpf_xdp_adjust_head
 
-SEC("xdp/test_bpf_xdp_adjust_head_0") int test_bpf_xdp_adjust_head_0(void** ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_0") int test_bpf_xdp_adjust_head_0(xdp_md_t* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, 0) < 0) {
-        return -1;
+        return XDP_DROP;
     }
-    return 0;
+    return XDP_PASS;
 }
 
-SEC("xdp/test_bpf_xdp_adjust_head_plus_100") int test_bpf_xdp_adjust_head_plus_100(void** ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_plus_100") int test_bpf_xdp_adjust_head_plus_100(xdp_md_t* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, 100) < 0) {
-        return -1;
+        return XDP_DROP;
     }
 
     if (bpf_xdp_adjust_head(ctx, -100) < 0) {
-        return -1;
+        return XDP_DROP;
     }
-    return 0;
+    return XDP_PASS;
 }
 
-SEC("xdp/test_bpf_xdp_adjust_head_minus_100") int test_bpf_xdp_adjust_head_minus_100(void** ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_minus_100") int test_bpf_xdp_adjust_head_minus_100(xdp_md_t* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, -100) < 0) {
-        return -1;
+        return XDP_DROP;
     }
     if (bpf_xdp_adjust_head(ctx, 100) < 0) {
-        return -1;
+        return XDP_DROP;
     }
-    return 0;
+    return XDP_PASS;
 }

--- a/bpf/xdp.c
+++ b/bpf/xdp.c
@@ -3,11 +3,11 @@
 
 #include "bpf.h"
 
-SEC("xdp/baseline") int test_xdp_baseline(xdp_md_t* ctx) { return XDP_PASS; }
+SEC("xdp/baseline") int test_xdp_baseline(void* ctx) { return XDP_PASS; }
 
 // Test cases for bpf_xdp_adjust_head
 
-SEC("xdp/test_bpf_xdp_adjust_head_0") int test_bpf_xdp_adjust_head_0(xdp_md_t* ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_0") int test_bpf_xdp_adjust_head_0(void* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, 0) < 0) {
         return XDP_DROP;
@@ -15,7 +15,7 @@ SEC("xdp/test_bpf_xdp_adjust_head_0") int test_bpf_xdp_adjust_head_0(xdp_md_t* c
     return XDP_PASS;
 }
 
-SEC("xdp/test_bpf_xdp_adjust_head_plus_100") int test_bpf_xdp_adjust_head_plus_100(xdp_md_t* ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_plus_100") int test_bpf_xdp_adjust_head_plus_100(void* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, 100) < 0) {
         return XDP_DROP;
@@ -27,7 +27,7 @@ SEC("xdp/test_bpf_xdp_adjust_head_plus_100") int test_bpf_xdp_adjust_head_plus_1
     return XDP_PASS;
 }
 
-SEC("xdp/test_bpf_xdp_adjust_head_minus_100") int test_bpf_xdp_adjust_head_minus_100(xdp_md_t* ctx)
+SEC("xdp/test_bpf_xdp_adjust_head_minus_100") int test_bpf_xdp_adjust_head_minus_100(void* ctx)
 {
     if (bpf_xdp_adjust_head(ctx, -100) < 0) {
         return XDP_DROP;

--- a/runner/runner.cc
+++ b/runner/runner.cc
@@ -206,6 +206,7 @@ main(int argc, char** argv)
             int batch_size;
             bool pass_data = false;
             bool pass_context = true;
+            uint32_t expected_result = 0;
 
             // Check if value "platform" is defined and matches the current platform.
             if (test["platform"].IsDefined()) {
@@ -236,6 +237,11 @@ main(int argc, char** argv)
             // Check if pass_context is defined and use it.
             if (test["pass_context"].IsDefined()) {
                 pass_context = test["pass_context"].as<bool>();
+            }
+
+            // Check if expected_result is defined and use it.
+            if (test["expected_result"].IsDefined()) {
+                expected_result = test["expected_result"].as<uint32_t>();
             }
 
             // Override batch size if specified on command line.
@@ -337,9 +343,9 @@ main(int argc, char** argv)
                     throw std::runtime_error("Failed to run map_state_preparation program " + prep_program_name);
                 }
 
-                if (opts.retval != 0) {
-                    std::string message = "map_state_preparation program " + prep_program_name + " returned non-zero " +
-                                          std::to_string(opts.retval);
+                if (opts.retval != expected_result) {
+                    std::string message = "map_state_preparation program " + prep_program_name + " returned unexpected value " +
+                                          std::to_string(opts.retval) + " expected " + std::to_string(expected_result);
                     if (ignore_return_code.value_or(false)) {
                         std::cout << message << std::endl;
                     } else {
@@ -457,11 +463,11 @@ main(int argc, char** argv)
                 thread.join();
             }
 
-            // Check if any program returned non-zero.
+            // Check if any program returned unexpected result.
             for (auto& opt : opts) {
-                if (opt.retval != 0) {
+                if (opt.retval != expected_result) {
                     std::string message =
-                        "Program returned non-zero " + std::to_string(opt.retval) + " in test " + name;
+                        "Program returned unexpected result " + std::to_string(opt.retval) + " in test " + name + " expected " + std::to_string(expected_result);
                     if (ignore_return_code.value_or(false)) {
                         std::cout << message << std::endl;
                     } else {


### PR DESCRIPTION
This pull request includes several changes to improve the testing and functionality of the `bpf` and `runner` components. The key changes involve the introduction of a new `expected_result` parameter for tests, updating the `test_xdp_baseline` function and other test functions in `xdp.c` to return `XDP_PASS` or `XDP_DROP` instead of 0 or -1, and the inclusion of a new header file `ebpf_nethooks.h` in `bpf.h.inc`.

Changes to `bpf`:

* [`bpf/bpf.h.inc`](diffhunk://#diff-92ef3e5ac5919a2a7f79114760ce786a41b477cadcdc8f1d920528c04ccf614cR13): Included a new header file `ebpf_nethooks.h` for Windows platform.
* [`bpf/xdp.c`](diffhunk://#diff-65eb7494128fca9176b7fadaf20e2352d784113c513afa14e69d0fc0058bc282L6-R38): Updated the `test_xdp_baseline` function and other test functions to return `XDP_PASS` or `XDP_DROP` instead of 0 or -1.

Changes to `runner`:

* [`runner/runner.cc`](diffhunk://#diff-e4084bb1e2b19ef14f8e7a29ff25e2142dc5ba49ca29534753848ada2db67b2fR209): Introduced a new `expected_result` parameter for tests. This parameter is used to check if the return value from the map_state_preparation program or any other program matches the expected result. [[1]](diffhunk://#diff-e4084bb1e2b19ef14f8e7a29ff25e2142dc5ba49ca29534753848ada2db67b2fR209) [[2]](diffhunk://#diff-e4084bb1e2b19ef14f8e7a29ff25e2142dc5ba49ca29534753848ada2db67b2fR242-R246) [[3]](diffhunk://#diff-e4084bb1e2b19ef14f8e7a29ff25e2142dc5ba49ca29534753848ada2db67b2fL340-R348) [[4]](diffhunk://#diff-e4084bb1e2b19ef14f8e7a29ff25e2142dc5ba49ca29534753848ada2db67b2fL460-R470)

Changes to tests:

* [`bpf/tests.yml`](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR386): Added `expected_result: 1` to several tests. This value will be used as the expected result in the tests. [[1]](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR386) [[2]](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR396) [[3]](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR406)