### PR TITLE
Handle case where test fails to exeute

### DIFF
--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -100,18 +100,43 @@ Wait-Job $Job
 Receive-Job $Job
 
 $values = get-content .\SendConnections.csv | convertfrom-csv | select-object -Property SendBps | ForEach-Object { [long]($_.SendBps) }  | Sort-Object
-$SendMedianConnectionBps = $values[$values.Length / 2]
+# If values is null or empty, set the median to 0
+if ($null -eq $values -or $values.Length -eq 0) {
+    Write-Error "No SendBps values found"
+    $SendMedianConnectionBps = 0
+} else {
+    $SendMedianConnectionBps = $values[$values.Length / 2]
+}
 Write-Output "Median SendConnectionBps: $SendMedianConnectionBps"
 
 $values = get-content .\SendStatus.csv | convertfrom-csv | select-object -Property SendBps | ForEach-Object { [long]($_.SendBps) }  | Sort-Object
-$SendMedianBps = $values[$values.Length / 2]
+# If values is null or empty, set the median to 0
+if ($null -eq $values -or $values.Length -eq 0) {
+    Write-Error "No SendBps values found"
+    $SendMedianBps = 0
+} else {
+    $SendMedianBps = $values[$values.Length / 2]
+}
 Write-Output "Median SendBps: $SendMedianBps"
 
 $values = get-content .\RecvConnections.csv | convertfrom-csv | select-object -Property RecvBps | ForEach-Object { [long]($_.RecvBps) }  | Sort-Object
-$RecvMedianConnectionBps = $values[$values.Length / 2]
+# If values is null or empty, set the median to 0
+if ($null -eq $values -or $values.Length -eq 0) {
+    Write-Error "No RecvBps values found"
+    $RecvMedianConnectionBps = 0
+} else {
+    $RecvMedianConnectionBps = $values[$values.Length / 2]
+}
 Write-Output "Median RecvConnectionBps: $RecvMedianConnectionBps"
 
 $values = get-content .\RecvStatus.csv | convertfrom-csv | select-object -Property RecvBps | ForEach-Object { [long]($_.RecvBps) }  | Sort-Object
+# If values is null or empty, set the median to 0
+if ($null -eq $values -or $values.Length -eq 0) {
+    Write-Error "No RecvBps values found"
+    $RecvMedianBps = 0
+} else {
+    $RecvMedianBps = $values[$values.Length / 2]
+}
 $RecvMedianBps = $values[$values.Length / 2]
 Write-Output "Median RecvBps: $RecvMedianBps"
 


### PR DESCRIPTION
This pull request includes changes to the `scripts/two-machine-perf.ps1` file to handle cases where certain variables may be null or empty. The changes ensure that if the `$values` variable is null or empty, an error message is written and the median is set to 0. This is done for four different variables: `$SendMedianConnectionBps`, `$SendMedianBps`, `$RecvMedianConnectionBps`, and `$RecvMedianBps`.

* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceR103-R139): Added null or empty checks for `$values`. If `$values` is null or empty, an error message is written and the median is set to 0. This is done for the variables `$SendMedianConnectionBps`, `$SendMedianBps`, `$RecvMedianConnectionBps`, and `$RecvMedianBps`.