### PR TITLE
Switch from error to warning

### DIFF
--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -102,7 +102,7 @@ Receive-Job $Job
 $values = get-content .\SendConnections.csv | convertfrom-csv | select-object -Property SendBps | ForEach-Object { [long]($_.SendBps) }  | Sort-Object
 # If values is null or empty, set the median to 0
 if ($null -eq $values -or $values.Length -eq 0) {
-    Write-Error "No SendBps values found"
+    Write-Warning "No RecvBps values found"
     $SendMedianConnectionBps = 0
 } else {
     $SendMedianConnectionBps = $values[$values.Length / 2]
@@ -112,7 +112,7 @@ Write-Output "Median SendConnectionBps: $SendMedianConnectionBps"
 $values = get-content .\SendStatus.csv | convertfrom-csv | select-object -Property SendBps | ForEach-Object { [long]($_.SendBps) }  | Sort-Object
 # If values is null or empty, set the median to 0
 if ($null -eq $values -or $values.Length -eq 0) {
-    Write-Error "No SendBps values found"
+    Write-Warning "No RecvBps values found"
     $SendMedianBps = 0
 } else {
     $SendMedianBps = $values[$values.Length / 2]
@@ -122,7 +122,7 @@ Write-Output "Median SendBps: $SendMedianBps"
 $values = get-content .\RecvConnections.csv | convertfrom-csv | select-object -Property RecvBps | ForEach-Object { [long]($_.RecvBps) }  | Sort-Object
 # If values is null or empty, set the median to 0
 if ($null -eq $values -or $values.Length -eq 0) {
-    Write-Error "No RecvBps values found"
+    Write-Warning "No RecvBps values found"
     $RecvMedianConnectionBps = 0
 } else {
     $RecvMedianConnectionBps = $values[$values.Length / 2]
@@ -132,7 +132,7 @@ Write-Output "Median RecvConnectionBps: $RecvMedianConnectionBps"
 $values = get-content .\RecvStatus.csv | convertfrom-csv | select-object -Property RecvBps | ForEach-Object { [long]($_.RecvBps) }  | Sort-Object
 # If values is null or empty, set the median to 0
 if ($null -eq $values -or $values.Length -eq 0) {
-    Write-Error "No RecvBps values found"
+    Write-Warning "No RecvBps values found"
     $RecvMedianBps = 0
 } else {
     $RecvMedianBps = $values[$values.Length / 2]


### PR DESCRIPTION
This pull request primarily modifies the error handling in the `scripts/two-machine-perf.ps1` file. The changes replace instances of `Write-Error` with `Write-Warning` when no values are found in various CSV files. This change will likely make the script more resilient to empty or missing data, as warnings do not halt script execution like errors do.

Here are the key changes:

* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL105-R105): Replaced `Write-Error "No SendBps values found"` with `Write-Warning "No RecvBps values found"` in the `Receive-Job $Job` section.
* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL115-R115): Replaced `Write-Error "No SendBps values found"` with `Write-Warning "No RecvBps values found"` in the `Write-Output "Median SendConnectionBps: $SendMedianConnectionBps"` section.
* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL125-R125): Replaced `Write-Error "No RecvBps values found"` with `Write-Warning "No RecvBps values found"` in the `Write-Output "Median SendBps: $SendMedianBps"` section.
* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL135-R135): Replaced `Write-Error "No RecvBps values found"` with `Write-Warning "No RecvBps values found"` in the `Write-Output "Median RecvConnectionBps: $RecvMedianConnectionBps"` section.