### PR TITLE
Download xdp-for-windows

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -129,6 +129,8 @@ jobs:
 
     - name: Download xdp-for-windows
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      env:
+          GH_TOKEN: ${{ github.token }}
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -132,16 +132,12 @@ jobs:
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'
-        $packageBaseUrl = Get-Content -Path "${{github.workspace}}/scripts/xdp_version.txt"
-        $packageUrl = $packageBaseUrl + "/xdp-for-windows.1.1.0.msi"
-        write-output "Downloading $packageUrl"
-        Invoke-WebRequest -Uri $packageUrl -OutFile xdp-for-windows.1.1.0.msi
+        $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
+        $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]
+        gh release download -R microsoft/xdp-for-windows $release.name
         dir *.msi
-        $packageUrl = $packageBaseUrl + "/xdp-devkit-x64-1.1.0.zip"
-        write-output "Downloading $packageUrl"
-        Invoke-WebRequest -Uri $packageUrl -OutFile xdp-devkit-x64-1.1.0.zip
         dir *.zip
-        Expand-Archive -Path "xdp-devkit-x64-1.1.0.zip" -DestinationPath .
+        Expand-Archive -Path "xdp-devkit-x64-${{env.XDP_VERSION}}.zip" -DestinationPath .
 
     - name: Install xdp-for-windows
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,6 +19,9 @@ on:
 permissions:
   contents: read
 
+env:
+  XDP_VERSION: '1.1.0'
+
 jobs:
   build:
 


### PR DESCRIPTION
This pull request primarily involves changes to the `.github/workflows/Build.yml` file to streamline the process of downloading and installing packages. The changes replace the previous method of manually specifying the package URL with the use of GitHub's `gh release` command to automatically fetch the latest pre-release. The package URL is no longer hardcoded, which makes the process more flexible and maintainable.

Key changes include:

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL135-R140): Replaced the manual specification of the package URL with the use of `gh release` command to fetch the latest pre-release. This change reduces the need for manual updates whenever a new version of the package is released.
* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL135-R140): Removed the hardcoded package URL for the `xdp-devkit-x64-1.1.0.zip` file and replaced it with a dynamic reference to the environment variable `XDP_VERSION`. This change allows the workflow to adapt to different versions of the package without needing to modify the script.