### PR TITLE
update cts settings

### DIFF
--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -62,7 +62,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Send tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -88,7 +88,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Recv tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -53,7 +53,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Send tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
@@ -79,7 +79,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Recv tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -53,7 +53,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Send tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:0 -timeLimit:$Duration -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp  -StatusUpdate:15000
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
@@ -62,7 +62,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Send tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:0 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp -StatusUpdate:15000
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -79,7 +79,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Recv tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:0 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp -StatusUpdate:15000
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
@@ -88,7 +88,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Recv tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:0 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp  -StatusUpdate:15000
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -143,15 +143,6 @@ Write-Output "Peak RecvBps: $RecvPeakBps"
 Write-Output "Tests completed. Cleaning up..."
 
 Write-Output "Debug logging"
-
-Write-Output "SendStatus"
-Get-Content .\SendStatus.csv
-Write-Output "SendConnections"
-Get-Content .\SendConnections.csv
-Write-Output "RecvStatus"
-Get-Content .\RecvStatus.csv
-Write-Output "RecvConnections"
-Get-Content .\RecvConnections.csv
 
 Remove-PSSession $Session
 

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -20,7 +20,7 @@ param (
     [string]$RemoteDir = "C:\_work",
 
     [Parameter(Mandatory = $false)]
-    [string]$Duration = "300000",
+    [string]$Duration = "60000",
 
     [Parameter(Mandatory = $false)]
     [bool]$CpuProfile = $false

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -53,7 +53,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Send tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
@@ -79,7 +79,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Recv tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {


### PR DESCRIPTION
This pull request includes changes to the `scripts/two-machine-perf.ps1` file. The changes modify the parameters for the `ctsTraffic.exe` command for both Send and Recv tests.

The most important changes are:

* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL65-R65): The command parameters for `ctsTraffic.exe` in Send tests have been modified to include `-Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp`
* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL91-R91): Similarly, the command parameters for `ctsTraffic.exe` in Recv tests have been updated to include `-Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp`

These changes seem to be aimed at adjusting the performance testing parameters for the `ctsTraffic.exe` command.