### PR TITLE
Revert "Bump actions/download-artifact from 2.1.1 to 4.1.7"

### DIFF
--- a/.github/workflows/UploadPerfResults.yml
+++ b/.github/workflows/UploadPerfResults.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Download performance result artifacts
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: results-Release-${{matrix.platform}}-none
         path: results


### PR DESCRIPTION
Reverts microsoft/bpf_performance#75