### PR TITLE
Connection count

### DIFF
--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -58,11 +58,11 @@ $CommonOptions += "-Verify:connection"
 $CommonOptions += "-PrePostRecvs:3"
 $CommonOptions += "-CpuSetGroupId:0"
 $CommonOptions += "-io:iocp"
+$CommonOptions += "-StatusUpdate:$SamplingInterval"
 
 $ClientOptions = @()
 $ClientOptions += $CommonOptions
 $ClientOptions += "-connections:$ConcurrentConnections"
-$ClientOptions += "-StatusUpdate::$SamplingInterval"
 
 Write-Output "Client options: $ClientOptions"
 Write-Output "Common options: $CommonOptions"

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -75,6 +75,7 @@ $Job = Invoke-Command -Session $Session -ScriptBlock {
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
+    wpr.exe -cancel
     Write-Output "Starting CPU profiling"
     wpr.exe -start CPU -filemode
 }

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -58,13 +58,14 @@ $CommonOptions += "-Verify:connection"
 $CommonOptions += "-PrePostRecvs:3"
 $CommonOptions += "-CpuSetGroupId:0"
 $CommonOptions += "-io:iocp"
-$CommonOptions += "-StatusUpdate::$SamplingInterval"
 
 $ClientOptions = @()
 $ClientOptions += $CommonOptions
 $ClientOptions += "-connections:$ConcurrentConnections"
+$ClientOptions += "-StatusUpdate::$SamplingInterval"
 
-
+Write-Output "Client options: $ClientOptions"
+Write-Output "Common options: $CommonOptions"
 
 # Find all the local and remote IP and MAC addresses.
 $RemoteAddress = [System.Net.Dns]::GetHostAddresses($Session.ComputerName)[0].IPAddressToString

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -46,6 +46,7 @@ if ($null -eq $Session) {
 }
 
 $SamplingInterval = $Duration / 12 # Default to 5 samples per second when running for 60 seconds
+Write-Output Sampling interval: $SamplingInterval
 
 $CommonOptions = @()
 $CommonOptions += "-consoleverbosity:1"

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -55,28 +55,10 @@ Copy-Item -ToSession $Session . -Destination $RemoteDir\cts-traffic -Recurse -Fo
 Write-Output "Running the tests on the remote machine"
 Write-Output "Starting the remote ctsTraffic.exe for Send tests"
 
-# Set RSS on NIC on remote machine
-$Job = Invoke-Command -Session $Session -ScriptBlock {
-    $processor_count = $env:NUMBER_OF_PROCESSORS / 2
-
-    $physical_nics = Get-NetAdapter | Where-Object -Property "PhysicalMediaType" -EQ "802.3"
-    foreach ($nic in $physical_nics) {
-        Set-NetAdapterRss -Name $nic.Name -MaxProcessors $processor_count -NumberOfReceiveQueues $processor_count
-    }
-}
-
-# Set RSS on NIC on local machine
-$physical_nics = Get-NetAdapter | Where-Object -Property "PhysicalMediaType" -EQ "802.3"
-$processor_count = $env:NUMBER_OF_PROCESSORS / 2
-foreach ($nic in $physical_nics) {
-    Write-Output "Setting RSS on $nic.Name to $processor_count processors"
-    Set-NetAdapterRss -Name $nic.Name -MaxProcessors $processor_count -NumberOfReceiveQueues $processor_count
-}
-
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -Buffer:1048576 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3  -CpuSetGroupId:0
 } -ArgumentList $RemoteDir, $Duration -AsJob
 
 if ($CpuProfile) {
@@ -86,7 +68,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Send tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration -Buffer:1048576 -connections:$ConcurrentConnections -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv -timeLimit:$Duration -Buffer:1048576 -connections:$ConcurrentConnections -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -CpuSetGroupId:0
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -103,7 +85,7 @@ Write-Output "Starting the remote ctsTraffic.exe for Recv tests"
 $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $Duration)
     $CtsTraffic = "$RemoteDir\cts-traffic\ctsTraffic.exe"
-    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -connections:$ConcurrentConnections -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+    &$CtsTraffic -listen:* -consoleverbosity:1 -timeLimit:$Duration -pattern:pull -Buffer:1048576 -connections:$ConcurrentConnections -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -CpuSetGroupId:0
 } -ArgumentList $RemoteDir, $Duration, $ConcurrentConnections -AsJob
 
 if ($CpuProfile) {
@@ -112,7 +94,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Recv tests"
-.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration -Buffer:1048576 -connections:32 -transfer:0xffffffffffff -MsgWaitAll:on  -Verify:connection -PrePostRecvs:3 -io:rioiocp
+.\ctsTraffic.exe -target:$RemoteAddress -consoleverbosity:1 -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull -timeLimit:$Duration -Buffer:1048576 -connections:$ConcurrentConnections  -transfer:0xffffffffffff -MsgWaitAll:on -Verify:connection -PrePostRecvs:3 -CpuSetGroupId:0
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -165,22 +147,6 @@ $RecvPeakBps = $values[$values.Length / 2]
 Write-Output "Peak RecvBps: $RecvPeakBps"
 
 Write-Output "Tests completed. Cleaning up..."
-
-# Set RSS on NIC on remote machine
-$Job = Invoke-Command -Session $Session -ScriptBlock {
-    $physical_nics = Get-NetAdapter | Where-Object -Property "PhysicalMediaType" -EQ "802.3"
-    foreach ($nic in $physical_nics) {
-        Set-NetAdapterRss -Name $nic.Name -MaxProcessors 8 -NumberOfReceiveQueues 8
-    }
-}
-
-# Set RSS on NIC on local machine
-$physical_nics = Get-NetAdapter | Where-Object -Property "PhysicalMediaType" -EQ "802.3"
-foreach ($nic in $physical_nics) {
-    Write-Output "Setting RSS on $nic.Name to 8 processors"
-    Set-NetAdapterRss -Name $nic.Name -MaxProcessors 8 -NumberOfReceiveQueues 8
-}
-
 
 Write-Output "Debug logging"
 

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -48,7 +48,6 @@ if ($null -eq $Session) {
 $CommonOptions = @()
 $CommonOptions += "-consoleverbosity:1"
 $CommonOptions += "-timeLimit:$Duration"
-$CommonOptions += "-connections:$ConcurrentConnections"
 $CommonOptions += "-Buffer:1048576"
 $CommonOptions += "-transfer:0xffffffffffff"
 $CommonOptions += "-MsgWaitAll:on"
@@ -56,6 +55,11 @@ $CommonOptions += "-Verify:connection"
 $CommonOptions += "-PrePostRecvs:3"
 $CommonOptions += "-CpuSetGroupId:0"
 $CommonOptions += "-io:iocp"
+
+$ClientOptions = @()
+$ClientOptions += $CommonOptions
+$ClientOptions += "-connections:$ConcurrentConnections"
+
 
 
 # Find all the local and remote IP and MAC addresses.
@@ -81,7 +85,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Send tests"
-.\ctsTraffic.exe -target:$RemoteAddress -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv $CommonOptions
+.\ctsTraffic.exe -target:$RemoteAddress -statusfilename:SendStatus.csv -connectionfilename:SendConnections.csv $ClientOptions
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"
@@ -107,7 +111,7 @@ if ($CpuProfile) {
 }
 
 Write-Output "Starting the local ctsTraffic.exe for Recv tests"
-.\ctsTraffic.exe -target:$RemoteAddress -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull $CommonOptions
+.\ctsTraffic.exe -target:$RemoteAddress -statusfilename:RecvStatus.csv -connectionfilename:RecvConnections.csv -pattern:pull $ClientOptions
 
 if ($CpuProfile) {
     Write-Output "Stopping CPU profiling"

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -45,6 +45,8 @@ if ($null -eq $Session) {
     Write-Error "Failed to create remote session"
 }
 
+$SamplingInterval = $Duration / 12 # Default to 5 samples per second when running for 60 seconds
+
 $CommonOptions = @()
 $CommonOptions += "-consoleverbosity:1"
 $CommonOptions += "-timeLimit:$Duration"
@@ -55,6 +57,7 @@ $CommonOptions += "-Verify:connection"
 $CommonOptions += "-PrePostRecvs:3"
 $CommonOptions += "-CpuSetGroupId:0"
 $CommonOptions += "-io:iocp"
+$CommonOptions += "-StatusUpdate::$SamplingInterval"
 
 $ClientOptions = @()
 $ClientOptions += $CommonOptions

--- a/scripts/two-machine-perf.ps1
+++ b/scripts/two-machine-perf.ps1
@@ -33,6 +33,8 @@ param (
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 #$ProgressPreference = 'SilentlyContinue'
 
+Write-Output "Running test with Config: $Config, Arch: $Arch, PeerName: $PeerName, RemotePSConfiguration: $RemotePSConfiguration, RemoteDir: $RemoteDir, Duration: $Duration, CpuProfile: $CpuProfile, ConcurrentConnections: $ConcurrentConnections"
+
 # Set up the connection to the peer over remote powershell.
 Write-Output "Connecting to $PeerName..."
 $Username = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultUserName


### PR DESCRIPTION
This pull request includes significant changes to the `scripts/two-machine-perf.ps1` file. The changes involve the addition of a new parameter, `ConcurrentConnections`, and the restructuring of command options for better code organization and reusability. 

Here are the most important changes:

Parameter Addition:

* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL26-R37): Added a new optional parameter `ConcurrentConnections` with a default value of 32. Additionally, a line was added to output the test configuration parameters, including the new `ConcurrentConnections` parameter.

Command Options Restructuring:

* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceR48-R69): Introduced variables `$CommonOptions` and `$ClientOptions` to hold the common and client-specific command options respectively. This change simplifies the command options and makes the code more maintainable.
* [`scripts/two-machine-perf.ps1`](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL54-R93): Modified the `Invoke-Command` script block parameters to use `$CommonOptions` instead of `$Duration`. This change allows the reuse of common command options in multiple places. [[1]](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL54-R93) [[2]](diffhunk://#diff-eed2abb1291f404c79ab0dda13caec5b5b0438ba2722713bc091a421db0526ceL80-R119)