### PR TITLE
Disable XDP until it's fixed

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -94,3 +94,23 @@ jobs:
       with:
         name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: ${{github.workspace}}/build/bin
+
+    - name: Self-Tests
+      if: inputs.platform == 'ubuntu-22.04'
+      working-directory: ${{github.workspace}}/build/bin
+      run: |
+        cmake --build ${{github.workspace}}/build --target test --
+
+    - name: Generate code coverage report
+      if: inputs.option == 'coverage'
+      run: |
+        mkdir -p coverage
+        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info --exclude '${{github.workspace}}/external/*' --exclude '${{github.workspace}}/build/*'
+
+    - name: Coveralls Parallel
+      if: inputs.option == 'coverage'
+      uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{inputs.build_type}}-${{inputs.platform}}-${{inputs.arch}}
+        parallel: true

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,10 +64,9 @@ jobs:
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
         mkdir ${{github.workspace}}/local_packages
-        $token = ConvertTo-SecureString -String ${{secrets.github_token}} -AsPlainText -Force
-        $workflow = ((Invoke-WebRequest -Uri  "https://api.github.com/repos/microsoft/ebpf-for-windows/actions/runs?per_page=1&exclude_pull_requests=true&branch=main&status=completed&event=schedule" -Token $token).Content | ConvertFrom-Json).workflow_runs[0]
-        $runId = $workflow.id
-        $commitSha = $workflow.head_sha
+        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json workflowDatabaseId,headSha -L 1 | ConvertFrom-Json)
+        $runId = $workflow.workflowDatabaseId
+        $commitSha = $workflow.headSha
         echo "RUNID=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "COMMIT_SHA=$commitSha" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -62,6 +62,8 @@ jobs:
 
     - name: Get the latest run ID from Microsoft/ebpf-for-windows main branch - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         mkdir ${{github.workspace}}/local_packages
         $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json workflowDatabaseId,headSha -L 1 | ConvertFrom-Json)

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -94,6 +94,11 @@ jobs:
         $artifacts += 'ebpf-for-windows - MSI installer (Build-x64_Release)'
         scripts\Fetch-LatestArtifacts.ps1 -ArtifactsToDownload $artifacts -OutputPath ${{github.workspace}}/local_packages -RunId ${{env.RUNID}} -GitHubToken $token
 
+    - name: Install MSVC Redist
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        choco install -y vcredist140
+
     - name: Configure CMake - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
@@ -181,6 +186,7 @@ jobs:
       run: |
         sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
         exit ${PIPESTATUS[0]}
+
 
     - name: Install prerequisites - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,9 +19,6 @@ on:
 permissions:
   contents: read
 
-env:
-  XDP_VERSION: '1.1.0'
-
 jobs:
   build:
 
@@ -60,45 +57,22 @@ jobs:
         sudo LIBDIR=/lib/x86_64-linux-gnu make install
         sudo ldconfig
 
-    - name: Get the latest run ID from Microsoft/ebpf-for-windows main branch - Windows-2019 or Windows-2022
+    - name: Download the ebpf-for-windows build nuget package
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        mkdir ${{github.workspace}}/local_packages
-        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json databaseId,headSha -L 1 | ConvertFrom-Json)
-        $runId = $workflow.databaseId
-        $commitSha = $workflow.headSha
-        echo "RUNID=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "COMMIT_SHA=$commitSha" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      uses: actions/download-artifact@b1f1d5
+      with:
+        name: ebpf-for-windows - NuGet package (none_Release)
+        path: ${{github.workspace}}/local_packages
 
     - name: Get Linux Kernel version
       if: inputs.platform == 'ubuntu-22.04'
       run: |
         echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
 
-    - name: Cache downloaded artifacts
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      with:
-        path: ${{github.workspace}}/local_packages
-        key: ${{inputs.platform}}-${{inputs.configuration}}-ebpf-for-windows-run-id-${{env.RUNID}}
-
-    - name: Download daily nuget package and MSI installer - Windows-2019 or Windows-2022
-      env:
-        GH_TOKEN: ${{ github.token }}
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        $token = ConvertTo-SecureString -String ${{secrets.github_token}} -AsPlainText -Force
-        $artifacts = @()
-        $artifacts += 'ebpf-for-windows - NuGet package (Build-x64_Release)'
-        $artifacts += 'ebpf-for-windows - MSI installer (Build-x64_Release)'
-        scripts\Fetch-LatestArtifacts.ps1 -ArtifactsToDownload $artifacts -OutputPath ${{github.workspace}}/local_packages -RunId ${{env.RUNID}} -GitHubToken $token
-
     - name: Configure CMake - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages -DBPF_PERF_LOCAL_MSI_PATH=${{github.workspace}}/local_packages
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages
 
     - name: Configure CMake - Ubuntu-22.04
       if: inputs.platform == 'ubuntu-22.04'
@@ -123,118 +97,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
       with:
-        name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}
+        name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: ${{github.workspace}}/build/bin
-
-    - name: Setup xdp directory
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        mkdir -p ${{github.workspace}}\xdp
-
-    - name: Download xdp-for-windows
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      env:
-          GH_TOKEN: ${{ github.token }}
-      working-directory: ${{ github.workspace }}\xdp
-      run: |
-        $ProgressPreference = 'SilentlyContinue'
-        $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
-        $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]
-        gh release download -R microsoft/xdp-for-windows $release.name
-        dir *.msi
-        dir *.zip
-        Expand-Archive -Path "xdp-devkit-x64-${{env.XDP_VERSION}}.zip" -DestinationPath .
-
-    - name: Install xdp-for-windows
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      working-directory: ${{ github.workspace }}\xdp
-      run: |
-          $installPath = "${{ github.workspace }}\xdp"
-          Write-Output "xdp installPath: $installPath"
-          Write-Output "Installing XDP for Windows"
-          CertUtil.exe -addstore Root bin\CoreNetSignRoot.cer
-          CertUtil.exe -addstore TrustedPublisher bin\CoreNetSignRoot.cer
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.1.1.0.msi INSTALLFOLDER=$installPath /qn" -PassThru
-          if ($process.ExitCode -ne 0) { exit $process.ExitCode }
-          Write-Output "XDP for Windows installed"
-          sc.exe query xdp
-          reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
-          sc.exe stop xdp
-          sc.exe start xdp
-
-    - name: Create results directory
-      run: |
-        mkdir -p ${{github.workspace}}/results
-
-    - name: Create commit_sha.txt - Windows-2019 or Windows-2022
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run:
-        echo ${{env.COMMIT_SHA}} | Out-File -FilePath ${{github.workspace}}/results/commit_sha.txt -Encoding utf8 -Append
-
-    - name: Create commit_sha.txt - Ubuntu-22.04
-      if: inputs.platform == 'ubuntu-22.04'
-      run: |
-        echo ${{env.COMMIT_SHA}} >> ${{github.workspace}}/results/commit_sha.txt
-
-    - name: Tests - Ubuntu-22.04
-      if: inputs.platform == 'ubuntu-22.04' && inputs.option == 'none'
-      working-directory: ${{github.workspace}}/build/bin
-      run: |
-        sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
-        exit ${PIPESTATUS[0]}
-
-
-    - name: Install prerequisites - Windows-2019 or Windows-2022
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      working-directory: ${{github.workspace}}/local_packages
-      run: |
-        Start-Process msiexec.exe -Wait -ArgumentList '/i ebpf-for-windows.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL'
-        echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-    - name: Tests - Windows 2019 or Windows 2022 - Native
-      if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'none'
-      working-directory: ${{github.workspace}}/build/bin
-      run: |
-        ${{env.BUILD_TYPE}}\bpf_performance_runner.exe -i tests.yml -e .sys -r | Tee-Object -FilePath ${{github.workspace}}/results/native-${inputs.platform}-${{env.BUILD_TYPE}}.csv
-
-    - name: Tests - Windows 2019 or Windows 2022 - JIT
-      if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'jit'
-      working-directory: ${{github.workspace}}/build/bin
-      # Run with option to ignore failing return code
-      run: |
-        ${{env.BUILD_TYPE}}\bpf_performance_runner.exe -i tests.yml -r | Tee-Object -FilePath ${{github.workspace}}/results/native-${inputs.platform}-${{env.BUILD_TYPE}}.csv
-
-    - name: Upload results
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
-      with:
-        name: results-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
-        path: |
-          ${{github.workspace}}/results/*.csv
-          ${{github.workspace}}/results/commit_sha.txt
-
-    - name: Upload profile
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
-      with:
-        name: profile-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
-        path: |
-          ${{github.workspace}}/results/*.etl
-
-    - name: Self-Tests
-      if: inputs.platform == 'ubuntu-22.04'
-      working-directory: ${{github.workspace}}/build/bin
-      run: |
-        cmake --build ${{github.workspace}}/build --target test --
-
-    - name: Generate code coverage report
-      if: inputs.option == 'coverage'
-      run: |
-        mkdir -p coverage
-        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info --exclude '${{github.workspace}}/external/*' --exclude '${{github.workspace}}/build/*'
-
-    - name: Coveralls Parallel
-      if: inputs.option == 'coverage'
-      uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
-      with:
-        github-token: ${{ secrets.github_token }}
-        flag-name: run-${{inputs.build_type}}-${{inputs.platform}}-${{inputs.arch}}
-        parallel: true

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -61,7 +61,7 @@ jobs:
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
-        name: ebpf-for-windows - NuGet package (none_Release)
+        name: "ebpf-for-windows - NuGet package (none_Release)"
         path: ${{github.workspace}}/local_packages
 
     - name: Get Linux Kernel version

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -95,11 +95,6 @@ jobs:
         $artifacts += 'ebpf-for-windows - MSI installer (Build-x64_Release)'
         scripts\Fetch-LatestArtifacts.ps1 -ArtifactsToDownload $artifacts -OutputPath ${{github.workspace}}/local_packages -RunId ${{env.RUNID}} -GitHubToken $token
 
-    - name: Install MSVC Redist
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        choco install -y vcredist140
-
     - name: Configure CMake - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Download the ebpf-for-windows build nuget package
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
         name: "ebpf-for-windows - NuGet package (none_Release)"
         path: ${{github.workspace}}/local_packages

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -100,6 +100,11 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages -DBPF_PERF_LOCAL_MSI_PATH=${{github.workspace}}/local_packages
 
+    - name: Test to see if bpf2c is working
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        build\packages\eBPF-for-Windows\build\native\bin\bpf2c.exe -?
+
     - name: Configure CMake - Ubuntu-22.04
       if: inputs.platform == 'ubuntu-22.04'
       run: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,11 +64,6 @@ jobs:
         name: "ebpf-for-windows - NuGet package (none_Release)"
         path: ${{github.workspace}}/local_packages
 
-    - name: Get Linux Kernel version
-      if: inputs.platform == 'ubuntu-22.04'
-      run: |
-        echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
-
     - name: Configure CMake - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
@@ -95,7 +90,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
         name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: ${{github.workspace}}/build/bin

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Download the ebpf-for-windows build nuget package
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/download-artifact@b1f1d5
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
       with:
         name: ebpf-for-windows - NuGet package (none_Release)
         path: ${{github.workspace}}/local_packages

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -66,8 +66,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         mkdir ${{github.workspace}}/local_packages
-        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json workflowDatabaseId,headSha -L 1 | ConvertFrom-Json)
-        $runId = $workflow.workflowDatabaseId
+        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json databaseId,headSha -L 1 | ConvertFrom-Json)
+        $runId = $workflow.databaseId
         $commitSha = $workflow.headSha
         echo "RUNID=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "COMMIT_SHA=$commitSha" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -100,11 +100,6 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages -DBPF_PERF_LOCAL_MSI_PATH=${{github.workspace}}/local_packages
 
-    - name: Test to see if bpf2c is working
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        build\packages\eBPF-for-Windows\build\native\bin\bpf2c.exe -?
-
     - name: Configure CMake - Ubuntu-22.04
       if: inputs.platform == 'ubuntu-22.04'
       run: |

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -53,24 +53,37 @@ jobs:
     with:
       platform: ${{ matrix.platform }}
       configuration: ${{ matrix.configuration }}
-      option: none
+      option: ${{ matrix.option }}
 
-  # test_bpf_performance:
-  #   name: Test BPF Performance
-  #   strategy:
-  #     matrix:
-  #       configuration: [ 'Release' ]
-  #       platform: [ 'windows-2019', 'windows-2022', 'ubuntu-22.04' ]
-  #       option: [ none, sanitizer, coverage, jit ]
-  #   uses: ./.github/workflows/Test.yml
-  #   with:
-  #     platform: ${{ matrix.platform }}
-  #     configuration: ${{ matrix.configuration }}
-  #     option: ${{ matrix.option }}
+  test_bpf_performance:
+    needs: build_bpf_performance
+    name: Test BPF Performance
+    strategy:
+      matrix:
+        configuration: [ 'Release' ]
+        platform: [ 'windows-2019', 'windows-2022', 'ubuntu-22.04' ]
+        option: [ none, sanitizer, coverage, jit ]
+        exclude:
+          - platform: windows-2019
+            option: sanitizer
+          - platform: windows-2019
+            option: coverage
+          - platform: windows-2022
+            option: sanitizer
+          - platform: windows-2022
+            option: coverage
+          - platform: ubuntu-22.04
+            option: jit
+
+    uses: ./.github/workflows/Test.yml
+    with:
+      platform: ${{ matrix.platform }}
+      configuration: ${{ matrix.configuration }}
+      option: ${{ matrix.option }}
 
   finish:
     needs:
-      - build_bpf_performance
+      - test_bpf_performance
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,6 +18,7 @@ permissions:
   id-token: write
   contents: read
   packages: write
+  security-events: write # Required by codeql task
 
 concurrency:
   # Cancel any CI/CD workflow currently in progress for the same PR.

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,25 +27,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_ebpf_for_windows:
-    name: Build ebpf-for-windows
-    uses: microsoft/ebpf-for-windows/.github/workflows/reusable-build.yml@main
-    with:
-      build_artifact: none
-      build_msi: true
-      build_nuget: true
-      build_options: /t:installer\ebpf-for-windows
-      repository: 'microsoft/ebpf-for-windows'
-      configurations: '["Release"]'
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
-      perform_skip_check: false
+  # build_ebpf_for_windows:
+  #   name: Build ebpf-for-windows
+  #   uses: microsoft/ebpf-for-windows/.github/workflows/reusable-build.yml@main
+  #   with:
+  #     build_artifact: none
+  #     build_msi: true
+  #     build_nuget: true
+  #     build_options: /t:installer\ebpf-for-windows
+  #     repository: 'microsoft/ebpf-for-windows'
+  #     configurations: '["Release"]'
+  #     ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
+  #     perform_skip_check: false
 
   build_and_test:
-    needs:
-      - build_ebpf_for_windows
+    # needs:
+    #   - build_ebpf_for_windows
     strategy:
       matrix:
-        configuration: [ 'Release', 'Debug' ]
+        configuration: [ 'Release' ]
         platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
         option: [ none, sanitizer, coverage, jit ]
         exclude:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -46,17 +46,18 @@ jobs:
     strategy:
       matrix:
         configuration: [ 'Release' ]
-        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
+        #platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
+        platform: [ 'ubuntu-22.04', 'windows-2019' ]
         option: [ none, sanitizer, coverage, jit ]
         exclude:
           - platform: windows-2019
             option: sanitizer
           - platform: windows-2019
             option: coverage
-          - platform: windows-2022
-            option: sanitizer
-          - platform: windows-2022
-            option: coverage
+          # - platform: windows-2022
+          #   option: sanitizer
+          # - platform: windows-2022
+          #   option: coverage
           - platform: ubuntu-22.04
             option: jit
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -85,6 +85,12 @@ jobs:
             option: coverage
           - platform: ubuntu-22.04
             option: jit
+          - platform: windows-2022
+            option: jit
+          - platform: windows-2019
+            option: jit
+          - platform: windows-2022
+            option: none
 
     uses: ./.github/workflows/Test.yml
     with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,6 +48,17 @@ jobs:
         configuration: [ 'Release', 'Debug' ]
         option: [ none, sanitizer, coverage ]
         platform: [ 'ubuntu-22.04', 'windows-2019' ]
+        exclude:
+          - platform: windows-2019
+            option: sanitizer
+          - platform: windows-2019
+            option: coverage
+          - platform: windows-2022
+            option: sanitizer
+          - platform: windows-2022
+            option: coverage
+          - platform: ubuntu-22.04
+            option: jit
 
     uses: ./.github/workflows/Build.yml
     with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -26,7 +26,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_ebpf_for_windows:
+    name: Build ebpf-for-windows
+    uses: microsoft/ebpf-for-windows/.github/workflows/reusable-build.yml@main
+    with:
+      build_artifact: none
+      build_msi: true
+      build_nuget: true
+      build_options: /t:installer\ebpf-for-windows
+      repository: 'microsoft/ebpf-for-windows'
+      configurations: '["Release"]'
+      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
+      perform_skip_check: false
+
   build_and_test:
+    needs:
+      - build_ebpf_for_windows
     strategy:
       matrix:
         configuration: [ 'Release', 'Debug' ]

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,7 +18,6 @@ permissions:
   id-token: write
   contents: read
   packages: write
-  security-events: write # Required by codeql task
 
 concurrency:
   # Cancel any CI/CD workflow currently in progress for the same PR.
@@ -27,37 +26,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # build_ebpf_for_windows:
-  #   name: Build ebpf-for-windows
-  #   uses: microsoft/ebpf-for-windows/.github/workflows/reusable-build.yml@main
-  #   with:
-  #     build_artifact: none
-  #     build_msi: true
-  #     build_nuget: true
-  #     build_options: /t:installer\ebpf-for-windows
-  #     repository: 'microsoft/ebpf-for-windows'
-  #     configurations: '["Release"]'
-  #     ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
-  #     perform_skip_check: false
-
   build_and_test:
-    # needs:
-    #   - build_ebpf_for_windows
     strategy:
       matrix:
-        configuration: [ 'Release' ]
-        #platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
-        platform: [ 'ubuntu-22.04', 'windows-2019' ]
+        configuration: [ 'Release', 'Debug' ]
+        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
         option: [ none, sanitizer, coverage, jit ]
         exclude:
           - platform: windows-2019
             option: sanitizer
           - platform: windows-2019
             option: coverage
-          # - platform: windows-2022
-          #   option: sanitizer
-          # - platform: windows-2022
-          #   option: coverage
+          - platform: windows-2022
+            option: sanitizer
+          - platform: windows-2022
+            option: none
+          - platform: windows-2022
+            option: jit
+          - platform: windows-2022
+            option: coverage
           - platform: ubuntu-22.04
             option: jit
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         configuration: [ 'Release' ]
         platform: [ 'windows-2019', 'windows-2022', 'ubuntu-22.04' ]
-        option: [ none, sanitizer, coverage, jit ]
+        option: [ none, jit ]
         exclude:
           - platform: windows-2019
             option: sanitizer

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -18,6 +18,7 @@ permissions:
   id-token: write
   contents: read
   packages: write
+  security-events: write # Required by codeql task
 
 concurrency:
   # Cancel any CI/CD workflow currently in progress for the same PR.
@@ -26,37 +27,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_test:
+  build_ebpf_for_windows:
+    name: Build ebpf-for-windows
+    uses: microsoft/ebpf-for-windows/.github/workflows/reusable-build.yml@main
+    with:
+      build_artifact: none
+      build_msi: true
+      build_nuget: true
+      build_options: /t:installer\ebpf-for-windows
+      repository: 'microsoft/ebpf-for-windows'
+      configurations: '["Release"]'
+      ref: main
+      perform_skip_check: false
+
+  build_bpf_performance:
+    needs: build_ebpf_for_windows
+    name: Build BPF Performance tests
     strategy:
       matrix:
         configuration: [ 'Release', 'Debug' ]
-        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
-        option: [ none, sanitizer, coverage, jit ]
-        exclude:
-          - platform: windows-2019
-            option: sanitizer
-          - platform: windows-2019
-            option: coverage
-          - platform: windows-2022
-            option: sanitizer
-          - platform: windows-2022
-            option: none
-          - platform: windows-2022
-            option: jit
-          - platform: windows-2022
-            option: coverage
-          - platform: ubuntu-22.04
-            option: jit
+        option: [ none, sanitizer, coverage ]
+        platform: [ 'ubuntu-22.04', 'windows-2019' ]
 
     uses: ./.github/workflows/Build.yml
     with:
       platform: ${{ matrix.platform }}
       configuration: ${{ matrix.configuration }}
-      option: ${{ matrix.option }}
+      option: none
+
+  # test_bpf_performance:
+  #   name: Test BPF Performance
+  #   strategy:
+  #     matrix:
+  #       configuration: [ 'Release' ]
+  #       platform: [ 'windows-2019', 'windows-2022', 'ubuntu-22.04' ]
+  #       option: [ none, sanitizer, coverage, jit ]
+  #   uses: ./.github/workflows/Test.yml
+  #   with:
+  #     platform: ${{ matrix.platform }}
+  #     configuration: ${{ matrix.configuration }}
+  #     option: ${{ matrix.option }}
 
   finish:
     needs:
-      - build_and_test
+      - build_bpf_performance
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -87,7 +87,7 @@ jobs:
   upload_results:
     if: github.event_name == 'schedule' || github.event_name == 'push'
     needs:
-      - build_and_test
+      - build_bpf_performance
     uses: ./.github/workflows/UploadPerfResults.yml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -80,6 +80,7 @@ jobs:
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
         name: "build-${{inputs.Configuration}}-${{inputs.platform}}-${{inputs.option}}"
+        path: ${{github.workspace}}/build/bin
 
     - name: Install prerequisites - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -56,100 +56,34 @@ jobs:
         sudo LIBDIR=/lib/x86_64-linux-gnu make install
         sudo ldconfig
 
-    - name: Get the latest run ID from Microsoft/ebpf-for-windows main branch - Windows-2019 or Windows-2022
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      env:
-        GH_TOKEN: ${{ github.token }}
+    - name: Get Linux Kernel version
+      if: inputs.platform == 'ubuntu-22.04'
       run: |
-        mkdir ${{github.workspace}}/local_packages
-        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json databaseId,headSha -L 1 | ConvertFrom-Json)
-        $runId = $workflow.databaseId
-        $commitSha = $workflow.headSha
-        echo "RUNID=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "COMMIT_SHA=$commitSha" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
+
+    - name: Download the eBPF for Windows MSI
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      with:
+        name: "ebpf-for-windows - MSI installer (none_Release)"
+        path: ${{github.workspace}}/local_packages
+
+    - name: Download BPF Performance tests
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      with:
+        name: "build-${{inputs.Configuration}}-${{inputs.platform}}-${{inputs.option}}"
+        path: ${{github.workspace}}/build/bin
 
     - name: Get Linux Kernel version
       if: inputs.platform == 'ubuntu-22.04'
       run: |
         echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
 
-    - name: Download daily nuget package and MSI installer - Windows-2019 or Windows-2022
-      env:
-        GH_TOKEN: ${{ github.token }}
+    - name: Get eBPF for Windows version
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       run: |
-        $token = ConvertTo-SecureString -String ${{secrets.github_token}} -AsPlainText -Force
-        $artifacts = @()
-        $artifacts += 'ebpf-for-windows - NuGet package (Build-x64_Release)'
-        $artifacts += 'ebpf-for-windows - MSI installer (Build-x64_Release)'
-        scripts\Fetch-LatestArtifacts.ps1 -ArtifactsToDownload $artifacts -OutputPath ${{github.workspace}}/local_packages -RunId ${{env.RUNID}} -GitHubToken $token
-
-    - name: Configure CMake - Windows-2019 or Windows-2022
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages -DBPF_PERF_LOCAL_MSI_PATH=${{github.workspace}}/local_packages
-
-    - name: Configure CMake - Ubuntu-22.04
-      if: inputs.platform == 'ubuntu-22.04'
-      run: |
-        if [ "${{inputs.option}}" = "sanitizer" ]; then
-          export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
-        fi
-        if [ "${{inputs.option}}" = "coverage" ]; then
-          export COVERAGE_FLAGS="-DCMAKE_CXX_FLAGS=\"--coverage\" -DCMAKE_C_FLAGS=\"--coverage\""
-        fi
-        cmake \
-          -B ${{github.workspace}}/build \
-          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-          -DCMAKE_CXX_FLAGS="${SANITIZER_FLAGS}" \
-          -DCMAKE_C_FLAGS="${SANITIZER_FLAGS}" \
-          ${COVERAGE_FLAGS}
-
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
-      with:
-        name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}
-        path: ${{github.workspace}}/build/bin
-
-    - name: Setup xdp directory
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        mkdir -p ${{github.workspace}}\xdp
-
-    - name: Download xdp-for-windows
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      env:
-          GH_TOKEN: ${{ github.token }}
-      working-directory: ${{ github.workspace }}\xdp
-      run: |
-        $ProgressPreference = 'SilentlyContinue'
-        $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
-        $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]
-        gh release download -R microsoft/xdp-for-windows $release.name
-        dir *.msi
-        dir *.zip
-        Expand-Archive -Path "xdp-devkit-x64-${{env.XDP_VERSION}}.zip" -DestinationPath .
-
-    - name: Install xdp-for-windows
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      working-directory: ${{ github.workspace }}\xdp
-      run: |
-          $installPath = "${{ github.workspace }}\xdp"
-          Write-Output "xdp installPath: $installPath"
-          Write-Output "Installing XDP for Windows"
-          CertUtil.exe -addstore Root bin\CoreNetSignRoot.cer
-          CertUtil.exe -addstore TrustedPublisher bin\CoreNetSignRoot.cer
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.1.1.0.msi INSTALLFOLDER=$installPath /qn" -PassThru
-          if ($process.ExitCode -ne 0) { exit $process.ExitCode }
-          Write-Output "XDP for Windows installed"
-          sc.exe query xdp
-          reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
-          sc.exe stop xdp
-          sc.exe start xdp
+        $version = (Get-Item "C:\Program Files\ebpf-for-windows\EbpfApi.dll").VersionInfo.FileVersion
+        echo "COMMIT_SHA=$version" >> $env:GITHUB_ENV
 
     - name: Create results directory
       run: |
@@ -171,7 +105,6 @@ jobs:
       run: |
         sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
         exit ${PIPESTATUS[0]}
-
 
     - name: Install prerequisites - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -79,12 +79,6 @@ jobs:
       run: |
         echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
 
-    - name: Get eBPF for Windows version
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        $version = (Get-Item "C:\Program Files\ebpf-for-windows\EbpfApi.dll").VersionInfo.FileVersion
-        echo "COMMIT_SHA=$version" >> $env:GITHUB_ENV
-
     - name: Create results directory
       run: |
         mkdir -p ${{github.workspace}}/results
@@ -112,6 +106,12 @@ jobs:
       run: |
         Start-Process msiexec.exe -Wait -ArgumentList '/i ebpf-for-windows.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL'
         echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Get eBPF for Windows version
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        $version = (Get-Item "C:\Program Files\ebpf-for-windows\EbpfApi.dll").VersionInfo.FileVersion
+        echo "COMMIT_SHA=$version" >> $env:GITHUB_ENV
 
     - name: Tests - Windows 2019 or Windows 2022 - Native
       if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'none'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -118,6 +118,7 @@ jobs:
       if: inputs.platform == 'ubuntu-22.04' && inputs.option == 'none'
       working-directory: ${{github.workspace}}/build/bin
       run: |
+        chmod a+x ./bpf_performance_runner
         sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
         exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -148,23 +148,3 @@ jobs:
         name: profile-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: |
           ${{github.workspace}}/results/*.etl
-
-    - name: Self-Tests
-      if: inputs.platform == 'ubuntu-22.04'
-      working-directory: ${{github.workspace}}/build/bin
-      run: |
-        cmake --build ${{github.workspace}}/build --target test --
-
-    - name: Generate code coverage report
-      if: inputs.option == 'coverage'
-      run: |
-        mkdir -p coverage
-        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info --exclude '${{github.workspace}}/external/*' --exclude '${{github.workspace}}/build/*'
-
-    - name: Coveralls Parallel
-      if: inputs.option == 'coverage'
-      uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
-      with:
-        github-token: ${{ secrets.github_token }}
-        flag-name: run-${{inputs.build_type}}-${{inputs.platform}}-${{inputs.arch}}
-        parallel: true

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,229 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      configuration:
+        required: true
+        type: string
+      option:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  XDP_VERSION: '1.1.0'
+
+jobs:
+  build:
+
+    runs-on: ${{inputs.platform}}
+    env:
+      BUILD_TYPE: ${{inputs.configuration}}
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      with:
+        egress-policy: audit
+
+    - name: Install prerequisites - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04'
+      run: |
+        sudo apt update
+        sudo apt-get install -y \
+         gcc-multilib \
+         lcov \
+         pkg-config \
+         libelf-dev \
+
+    - name: Clone and build libbpf - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04'
+      run: |
+        git clone https://github.com/libbpf/libbpf.git
+        cd libbpf
+        git checkout v0.7.0
+        cd src
+        make
+        sudo LIBDIR=/lib/x86_64-linux-gnu make install
+        sudo ldconfig
+
+    - name: Get the latest run ID from Microsoft/ebpf-for-windows main branch - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        mkdir ${{github.workspace}}/local_packages
+        $workflow = (gh run list -R microsoft/ebpf-for-windows  -e schedule -w "CI/CD" --json databaseId,headSha -L 1 | ConvertFrom-Json)
+        $runId = $workflow.databaseId
+        $commitSha = $workflow.headSha
+        echo "RUNID=$runId" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "COMMIT_SHA=$commitSha" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Get Linux Kernel version
+      if: inputs.platform == 'ubuntu-22.04'
+      run: |
+        echo "COMMIT_SHA=$(uname -r)" >> $env:GITHUB_ENV
+
+    - name: Download daily nuget package and MSI installer - Windows-2019 or Windows-2022
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        $token = ConvertTo-SecureString -String ${{secrets.github_token}} -AsPlainText -Force
+        $artifacts = @()
+        $artifacts += 'ebpf-for-windows - NuGet package (Build-x64_Release)'
+        $artifacts += 'ebpf-for-windows - MSI installer (Build-x64_Release)'
+        scripts\Fetch-LatestArtifacts.ps1 -ArtifactsToDownload $artifacts -OutputPath ${{github.workspace}}/local_packages -RunId ${{env.RUNID}} -GitHubToken $token
+
+    - name: Configure CMake - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBPF_PERF_LOCAL_NUGET_PATH=${{github.workspace}}/local_packages -DBPF_PERF_LOCAL_MSI_PATH=${{github.workspace}}/local_packages
+
+    - name: Configure CMake - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04'
+      run: |
+        if [ "${{inputs.option}}" = "sanitizer" ]; then
+          export SANITIZER_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+        fi
+        if [ "${{inputs.option}}" = "coverage" ]; then
+          export COVERAGE_FLAGS="-DCMAKE_CXX_FLAGS=\"--coverage\" -DCMAKE_C_FLAGS=\"--coverage\""
+        fi
+        cmake \
+          -B ${{github.workspace}}/build \
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+          -DCMAKE_CXX_FLAGS="${SANITIZER_FLAGS}" \
+          -DCMAKE_C_FLAGS="${SANITIZER_FLAGS}" \
+          ${COVERAGE_FLAGS}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      with:
+        name: build-${{env.BUILD_TYPE}}-${{inputs.platform}}
+        path: ${{github.workspace}}/build/bin
+
+    - name: Setup xdp directory
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        mkdir -p ${{github.workspace}}\xdp
+
+    - name: Download xdp-for-windows
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      env:
+          GH_TOKEN: ${{ github.token }}
+      working-directory: ${{ github.workspace }}\xdp
+      run: |
+        $ProgressPreference = 'SilentlyContinue'
+        $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
+        $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]
+        gh release download -R microsoft/xdp-for-windows $release.name
+        dir *.msi
+        dir *.zip
+        Expand-Archive -Path "xdp-devkit-x64-${{env.XDP_VERSION}}.zip" -DestinationPath .
+
+    - name: Install xdp-for-windows
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      working-directory: ${{ github.workspace }}\xdp
+      run: |
+          $installPath = "${{ github.workspace }}\xdp"
+          Write-Output "xdp installPath: $installPath"
+          Write-Output "Installing XDP for Windows"
+          CertUtil.exe -addstore Root bin\CoreNetSignRoot.cer
+          CertUtil.exe -addstore TrustedPublisher bin\CoreNetSignRoot.cer
+          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.1.1.0.msi INSTALLFOLDER=$installPath /qn" -PassThru
+          if ($process.ExitCode -ne 0) { exit $process.ExitCode }
+          Write-Output "XDP for Windows installed"
+          sc.exe query xdp
+          reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
+          sc.exe stop xdp
+          sc.exe start xdp
+
+    - name: Create results directory
+      run: |
+        mkdir -p ${{github.workspace}}/results
+
+    - name: Create commit_sha.txt - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run:
+        echo ${{env.COMMIT_SHA}} | Out-File -FilePath ${{github.workspace}}/results/commit_sha.txt -Encoding utf8 -Append
+
+    - name: Create commit_sha.txt - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04'
+      run: |
+        echo ${{env.COMMIT_SHA}} >> ${{github.workspace}}/results/commit_sha.txt
+
+    - name: Tests - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04' && inputs.option == 'none'
+      working-directory: ${{github.workspace}}/build/bin
+      run: |
+        sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
+        exit ${PIPESTATUS[0]}
+
+
+    - name: Install prerequisites - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      working-directory: ${{github.workspace}}/local_packages
+      run: |
+        Start-Process msiexec.exe -Wait -ArgumentList '/i ebpf-for-windows.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL'
+        echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Tests - Windows 2019 or Windows 2022 - Native
+      if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'none'
+      working-directory: ${{github.workspace}}/build/bin
+      run: |
+        ${{env.BUILD_TYPE}}\bpf_performance_runner.exe -i tests.yml -e .sys -r | Tee-Object -FilePath ${{github.workspace}}/results/native-${inputs.platform}-${{env.BUILD_TYPE}}.csv
+
+    - name: Tests - Windows 2019 or Windows 2022 - JIT
+      if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'jit'
+      working-directory: ${{github.workspace}}/build/bin
+      # Run with option to ignore failing return code
+      run: |
+        ${{env.BUILD_TYPE}}\bpf_performance_runner.exe -i tests.yml -r | Tee-Object -FilePath ${{github.workspace}}/results/native-${inputs.platform}-${{env.BUILD_TYPE}}.csv
+
+    - name: Upload results
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      with:
+        name: results-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
+        path: |
+          ${{github.workspace}}/results/*.csv
+          ${{github.workspace}}/results/commit_sha.txt
+
+    - name: Upload profile
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      with:
+        name: profile-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
+        path: |
+          ${{github.workspace}}/results/*.etl
+
+    - name: Self-Tests
+      if: inputs.platform == 'ubuntu-22.04'
+      working-directory: ${{github.workspace}}/build/bin
+      run: |
+        cmake --build ${{github.workspace}}/build --target test --
+
+    - name: Generate code coverage report
+      if: inputs.option == 'coverage'
+      run: |
+        mkdir -p coverage
+        lcov --capture --directory build --include '${{github.workspace}}/*' --output-file coverage/lcov.info --exclude '${{github.workspace}}/external/*' --exclude '${{github.workspace}}/build/*'
+
+    - name: Coveralls Parallel
+      if: inputs.option == 'coverage'
+      uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{inputs.build_type}}-${{inputs.platform}}-${{inputs.arch}}
+        parallel: true

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
-name: Build
+name: Test
 
 on:
   workflow_call:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -68,11 +68,18 @@ jobs:
         name: "ebpf-for-windows - MSI installer (none_Release)"
         path: ${{github.workspace}}/local_packages
 
-    - name: Download BPF Performance tests
+    - name: Download BPF Performance tests - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      with:
+        name: "build-${{inputs.Configuration}}-windows-2019-none"
+        path: ${{github.workspace}}/build/bin
+
+    - name: Download BPF Performance tests - Ubuntu-22.04
+      if: inputs.platform == 'ubuntu-22.04'
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
         name: "build-${{inputs.Configuration}}-${{inputs.platform}}-${{inputs.option}}"
-        path: ${{github.workspace}}/build/bin
 
     - name: Install prerequisites - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -74,6 +74,19 @@ jobs:
         name: "build-${{inputs.Configuration}}-${{inputs.platform}}-${{inputs.option}}"
         path: ${{github.workspace}}/build/bin
 
+    - name: Install prerequisites - Windows-2019 or Windows-2022
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      working-directory: ${{github.workspace}}/local_packages
+      run: |
+        Start-Process msiexec.exe -Wait -ArgumentList '/i ebpf-for-windows.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL'
+        echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Get eBPF for Windows version
+      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
+      run: |
+        $version = (Get-Item "C:\Program Files\ebpf-for-windows\EbpfApi.dll").VersionInfo.FileVersion
+        echo "COMMIT_SHA=$version" >> $env:GITHUB_ENV
+
     - name: Get Linux Kernel version
       if: inputs.platform == 'ubuntu-22.04'
       run: |
@@ -99,19 +112,6 @@ jobs:
       run: |
         sudo ./bpf_performance_runner -i tests.yml -r | tee ${{github.workspace}}/results/jit-${{inputs.platform}}-${{env.BUILD_TYPE}}.csv
         exit ${PIPESTATUS[0]}
-
-    - name: Install prerequisites - Windows-2019 or Windows-2022
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      working-directory: ${{github.workspace}}/local_packages
-      run: |
-        Start-Process msiexec.exe -Wait -ArgumentList '/i ebpf-for-windows.msi /quiet /qn /norestart /log install.log ADDLOCAL=ALL'
-        echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-    - name: Get eBPF for Windows version
-      if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      run: |
-        $version = (Get-Item "C:\Program Files\ebpf-for-windows\EbpfApi.dll").VersionInfo.FileVersion
-        echo "COMMIT_SHA=$version" >> $env:GITHUB_ENV
 
     - name: Tests - Windows 2019 or Windows 2022 - Native
       if: (inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022') && inputs.option == 'none'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -74,22 +74,12 @@ jobs:
     - name: Install prerequisites
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-multilib libbpf-dev
+        sudo apt-get install -y gcc-multilib libbpf-dev libelf-dev
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@9fdb3e49720b44c48891d036bb502feb25684276 # v3.25.6
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+    - name: Build
+      run: |
+        cmake -B build -S .
+        cmake --build build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@9fdb3e49720b44c48891d036bb502feb25684276 # v3.25.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,20 +35,22 @@ if (PLATFORM_WINDOWS)
   # Run  export_program_info.exe from the eBPF-for-Windows package
   execute_process(COMMAND "${EBPF_BIN_PATH}/export_program_info.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
 
-  # Download the XDP-dev-kit from GitHub
-  file(READ "${CMAKE_SOURCE_DIR}/scripts/xdp_version.txt" XDP_VERSION)
-  file(DOWNLOAD "${XDP_VERSION}/xdp-devkit-x64-1.1.0.zip" "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip")
-  # Unzip the XDP-dev-kit
-  # Create folder xdp-devkit
-  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
-  # Unzip the xdp-devkit.zip file into the xdp-devkit folder
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip" WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
+  if (BPF_XDP_TEST_ENABLED)
+    # Download the XDP-dev-kit from GitHub
+    file(READ "${CMAKE_SOURCE_DIR}/scripts/xdp_version.txt" XDP_VERSION)
+    file(DOWNLOAD "${XDP_VERSION}/xdp-devkit-x64-1.1.0.zip" "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip")
+    # Unzip the XDP-dev-kit
+    # Create folder xdp-devkit
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
+    # Unzip the xdp-devkit.zip file into the xdp-devkit folder
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf "${PROJECT_BINARY_DIR}/packages/xdp-devkit.zip" WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/packages/xdp-devkit")
 
-  SET(XDP_INC_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/include")
-  SET(XDP_LIB_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/lib")
-  SET(XDP_BIN_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin")
-  # Run xdp_bpfexport.exe from the xdp-dev-kit
-  execute_process(COMMAND "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin/xdp_bpfexport.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
+    SET(XDP_INC_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/include")
+    SET(XDP_LIB_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/lib")
+    SET(XDP_BIN_PATH "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin")
+    # Run xdp_bpfexport.exe from the xdp-dev-kit
+    execute_process(COMMAND "${PROJECT_BINARY_DIR}/packages/xdp-devkit/bin/xdp_bpfexport.exe" WORKING_DIRECTORY "${EBPF_BIN_PATH}" COMMAND_ERROR_IS_FATAL ANY)
+  endif()
 elseif(PLATFORM_LINUX)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(LIBBPF REQUIRED libbpf)

--- a/bpf/CMakeLists.txt
+++ b/bpf/CMakeLists.txt
@@ -43,7 +43,7 @@ function(process_test_cases worker test_list)
         list(GET elements 0 file_name)
         list(GET elements 1 out_name)
         list(REMOVE_AT elements 0 1)
-        
+
         # Build the option_list from the remaining elements
         set(option_list "")
         foreach(element IN LISTS elements)

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -381,6 +381,7 @@ tests:
     description: Tests the bpf_xdp_adjust_head helper.
     elf_file: xdp.o
     iteration_count: 1000000
+    platform: Linux
     program_type: xdp
     pass_data: true
     expected_result: 1
@@ -391,6 +392,7 @@ tests:
     description: Tests the bpf_xdp_adjust_head helper.
     elf_file: xdp.o
     iteration_count: 1000000
+    platform: Linux
     program_type: xdp
     pass_data: true
     expected_result: 1

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -403,6 +403,7 @@ tests:
     description: Tests the bpf_xdp_adjust_head helper.
     elf_file: xdp.o
     iteration_count: 1000000
+    platform: Linux
     program_type: xdp
     pass_data: true
     expected_result: 1

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -484,14 +484,14 @@ tests:
     iteration_count: 10000000
     program_cpu_assignment:
       output: all
-  
+
   - name: BPF_MAP_TYPE_RINGBUF output - 300K entries of 400bytes
     description: Tests the bpf_ringbuf_output helper writing 300K entries of 400bytes.
     elf_file: ringbuf_300K_400b.o
     iteration_count: 300000
     program_cpu_assignment:
       output: all
-  
+
   - name: BPF_MAP_TYPE_RINGBUF output - 100K entries of 1420bytes
     description: Tests the bpf_ringbuf_output helper writing 100K entries of 1420bytes.
     elf_file: ringbuf_100K_1420b.o

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -3,6 +3,7 @@
 
 option(BPF_PERF_INSTALL_GIT_HOOKS "Set to true to install git hooks" ON)
 option(BPF_PERF_LOCAL_NUGET_PATH "Use a local NuGet package to install dependencies")
+option(BPF_XDP_TEST_ENABLED "Set to true to enable XDP tests")
 
 # Note that the compile_commands.json file is only exporter when
 # using the Ninja or Makefile generator


### PR DESCRIPTION
This pull request primarily focuses on enabling XDP tests in the build process for both Windows and Linux platforms. The changes include adding a new option to enable XDP tests in the CMake configuration, downloading the XDP dev-kit when the tests are enabled, and specifying the platform for certain tests in the test configuration file.

Enabling XDP tests:

* [`cmake/options.cmake`](diffhunk://#diff-e8bc1b52c7618188b02120d369a4664f177556455e9a3c705d82b2cfd098d9c8R6): Added a new option `BPF_XDP_TEST_ENABLED` to enable XDP tests in the CMake configuration.

Downloading XDP dev-kit:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR38): If `BPF_XDP_TEST_ENABLED` is set, the XDP dev-kit is downloaded for Windows. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR38) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR53)

Specifying platform for tests:

* [`bpf/tests.yml`](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR384): Added a `platform: Linux` specification for certain tests in the test configuration file. [[1]](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR384) [[2]](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbR395)