### PR TITLE
Reenable Server 2022

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -85,12 +85,6 @@ jobs:
             option: coverage
           - platform: ubuntu-22.04
             option: jit
-          - platform: windows-2022
-            option: jit
-          - platform: windows-2019
-            option: jit
-          - platform: windows-2022
-            option: none
 
     uses: ./.github/workflows/Test.yml
     with:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -85,6 +85,10 @@ jobs:
             option: coverage
           - platform: ubuntu-22.04
             option: jit
+          - platform: windows-2022
+            option: jit
+          - platform: windows-2019
+            option: jit
 
     uses: ./.github/workflows/Test.yml
     with:


### PR DESCRIPTION
Server 2022 variants are disabled as they fail. This change reenables them as part of an investigation.