### PR TITLE
Select correct actions/download-artifact instance

### DIFF
--- a/.github/workflows/UploadPerfResults.yml
+++ b/.github/workflows/UploadPerfResults.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     - name: Download performance result artifacts
-      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
         name: results-Release-${{matrix.platform}}-none
         path: results


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/UploadPerfResults.yml` file. The change updates the version of the `actions/download-artifact` action used in the `Download performance result artifacts` job.