### PR TITLE
Switch to latest artifact code

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Download the ebpf-for-windows build nuget package
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: "ebpf-for-windows - NuGet package (none_Release)"
         path: ${{github.workspace}}/local_packages

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -136,7 +136,7 @@ jobs:
         ${{env.BUILD_TYPE}}\bpf_performance_runner.exe -i tests.yml -r | Tee-Object -FilePath ${{github.workspace}}/results/native-${inputs.platform}-${{env.BUILD_TYPE}}.csv
 
     - name: Upload results
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
         name: results-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: |
@@ -144,7 +144,7 @@ jobs:
           ${{github.workspace}}/results/commit_sha.txt
 
     - name: Upload profile
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
       with:
         name: profile-${{env.BUILD_TYPE}}-${{inputs.platform}}-${{inputs.option}}
         path: |

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -63,21 +63,21 @@ jobs:
 
     - name: Download the eBPF for Windows MSI
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: "ebpf-for-windows - MSI installer (none_Release)"
         path: ${{github.workspace}}/local_packages
 
     - name: Download BPF Performance tests - Windows-2019 or Windows-2022
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: "build-${{inputs.Configuration}}-windows-2019-none"
         path: ${{github.workspace}}/build/bin
 
     - name: Download BPF Performance tests - Ubuntu-22.04
       if: inputs.platform == 'ubuntu-22.04'
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: "build-${{inputs.Configuration}}-${{inputs.platform}}-${{inputs.option}}"
         path: ${{github.workspace}}/build/bin

--- a/.github/workflows/UploadPerfResults.yml
+++ b/.github/workflows/UploadPerfResults.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Download performance result artifacts
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
       with:
         name: results-Release-${{matrix.platform}}-none
         path: results

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
@@ -63,7 +66,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
This pull request primarily updates the version of GitHub Actions used in several workflow files. The changes include updating the `download-artifact` and `upload-artifact` actions across multiple workflows, and adding a copyright notice to the `scorecards.yml` file.

Here are the key changes:

**GitHub Actions Version Updates:**

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcL62-R62): Updated the `download-artifact` action version.
* [`.github/workflows/Test.yml`](diffhunk://#diff-72ac9077b29c063d50efee3283761c2f665031b5882fd1210fabf424a7a64552L66-R80): Updated the `download-artifact` action version in multiple jobs and the `upload-artifact` action version. [[1]](diffhunk://#diff-72ac9077b29c063d50efee3283761c2f665031b5882fd1210fabf424a7a64552L66-R80) [[2]](diffhunk://#diff-72ac9077b29c063d50efee3283761c2f665031b5882fd1210fabf424a7a64552L139-R147)
* [`.github/workflows/UploadPerfResults.yml`](diffhunk://#diff-c89000e19beb4c24f547ea54db6d5ecd603f686733c56775e481a2c3853a2caeL40-R40): Updated the `download-artifact` action version.
* [`.github/workflows/scorecards.yml`](diffhunk://#diff-649a84adf982ddf68273f1bb0de882a20e97b06632b5432a6a1504a3f23cb2e6L66-R69): Updated the `upload-artifact` action version.

**Other Changes:**

* [`.github/workflows/scorecards.yml`](diffhunk://#diff-649a84adf982ddf68273f1bb0de882a20e97b06632b5432a6a1504a3f23cb2e6R1-R3): Added a copyright notice at the top of the file.