### PR TITLE
Disable XDP support until fixed

### DIFF
--- a/bpf/CMakeLists.txt
+++ b/bpf/CMakeLists.txt
@@ -29,7 +29,8 @@ set(test_cases
     "ringbuf,ringbuf_100K_1420b,-DBPF -DRB_SIZE=268435456 -DRECORD_SIZE=1420"
     "rolling_lru,rolling_lru,-DBPF"
     "tail_call,tail_call,-DBPF"
-    "xdp,xdp,-DBPF"
+    # XDP disabled due to removal of XDP support in the eBPF runtime
+    #"xdp,xdp,-DBPF"
     "max_tail_call,max_tail_call,-DBPF"
     )
 

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -377,38 +377,39 @@ tests:
     program_cpu_assignment:
       tail_call: all
 
-  - name: bpf_xdp_adjust_head_zero
-    description: Tests the bpf_xdp_adjust_head helper.
-    elf_file: xdp.o
-    iteration_count: 1000000
-    platform: Linux
-    program_type: xdp
-    pass_data: true
-    expected_result: 1
-    program_cpu_assignment:
-      test_bpf_xdp_adjust_head_0: all
+  # Disabled due to removal of xdp_md from the BPF headers.
+  # - name: bpf_xdp_adjust_head_zero
+  #   description: Tests the bpf_xdp_adjust_head helper.
+  #   elf_file: xdp.o
+  #   iteration_count: 1000000
+  #   platform: Linux
+  #   program_type: xdp
+  #   pass_data: true
+  #   expected_result: 1
+  #   program_cpu_assignment:
+  #     test_bpf_xdp_adjust_head_0: all
 
-  - name: bpf_xdp_adjust_head_positive
-    description: Tests the bpf_xdp_adjust_head helper.
-    elf_file: xdp.o
-    iteration_count: 1000000
-    platform: Linux
-    program_type: xdp
-    pass_data: true
-    expected_result: 1
-    program_cpu_assignment:
-      test_bpf_xdp_adjust_head_plus_100: all
+  # - name: bpf_xdp_adjust_head_positive
+  #   description: Tests the bpf_xdp_adjust_head helper.
+  #   elf_file: xdp.o
+  #   iteration_count: 1000000
+  #   platform: Linux
+  #   program_type: xdp
+  #   pass_data: true
+  #   expected_result: 1
+  #   program_cpu_assignment:
+  #     test_bpf_xdp_adjust_head_plus_100: all
 
-  - name: bpf_xdp_adjust_head_negative
-    description: Tests the bpf_xdp_adjust_head helper.
-    elf_file: xdp.o
-    iteration_count: 1000000
-    platform: Linux
-    program_type: xdp
-    pass_data: true
-    expected_result: 1
-    program_cpu_assignment:
-      test_bpf_xdp_adjust_head_minus_100: all
+  # - name: bpf_xdp_adjust_head_negative
+  #   description: Tests the bpf_xdp_adjust_head helper.
+  #   elf_file: xdp.o
+  #   iteration_count: 1000000
+  #   platform: Linux
+  #   program_type: xdp
+  #   pass_data: true
+  #   expected_result: 1
+  #   program_cpu_assignment:
+  #     test_bpf_xdp_adjust_head_minus_100: all
 
   - name: bpf_tail_callee_max
     description: Tests the max tail call callees.


### PR DESCRIPTION
This pull request includes changes to disable XDP-related test cases and configurations due to the removal of XDP support in the eBPF runtime and the removal of `xdp_md` from the BPF headers.

Disabling XDP support:

* [`bpf/CMakeLists.txt`](diffhunk://#diff-19b5a8db8b8f944d204fa9873a1ac4141caca94d6894e1d59460f08bcb002e44L32-R33): Disabled the XDP test case in the `test_cases` set.

Disabling XDP-related tests:

* [`bpf/tests.yml`](diffhunk://#diff-12a98a6047a7256713674bdf82fafb0eda54ef1f4b7db6735da800ec7b5a7dcbL380-R412): Commented out multiple XDP-related test cases due to the removal of `xdp_md` from the BPF headers.