### PR TITLE
Remove unused permissions

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -17,8 +17,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  packages: write
-  security-events: write # Required by codeql task
 
 concurrency:
   # Cancel any CI/CD workflow currently in progress for the same PR.


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/CICD.yml` file to adjust the permissions settings for the CI/CD workflow.

Permissions adjustment:

* [`.github/workflows/CICD.yml`](diffhunk://#diff-fdc42f85e64d73f2d88830f87cfb3c6f32c93a440ed1aaaf6bfbcb8648fb9defL20-L21): Removed `packages: write` and `security-events: write` permissions, which were previously required by the CodeQL task.