### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change adds a new group for `actions` with a pattern to match all files.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R10): Added a new group for `actions` with a pattern to match all files.