### PR TITLE
Enable merge_group trigger

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -13,6 +13,7 @@ on:
   # Run on a daily schedule to perform the full set of tests.
   schedule:
     - cron: '00 21 * * *'
+  merge_group:
 
 permissions:
   id-token: write


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to add a new event trigger. The change introduces the `merge_group` event to the workflow.

* [`.github/workflows/CICD.yml`](diffhunk://#diff-fdc42f85e64d73f2d88830f87cfb3c6f32c93a440ed1aaaf6bfbcb8648fb9defR16): Added `merge_group` event to the workflow triggers.