### PR TITLE
Add default arguments

### DIFF
--- a/scripts/check_perf_results.sql
+++ b/scripts/check_perf_results.sql
@@ -12,6 +12,30 @@ The script uses the following parameters:
 - repository: The repository to filter the results by.
 */
 
+\if :{?platform}
+    \set platform :platform
+\else
+    \set platform 'Windows 2019'
+\endif
+
+\if :{?max_sigma}
+    \set max_sigma :max_sigma
+\else
+    \set max_sigma '2'
+\endif
+
+\if :{?look_back}
+    \set look_back :look_back
+\else
+    \set look_back '30 days'
+\endif
+
+\if :{?repository}
+    \set repository :repository
+\else
+    \set repository 'microsoft/ebpf-for-windows'
+\endif
+
 WITH samples AS (
     SELECT metric, value, "timestamp",
            ROW_NUMBER() OVER (PARTITION BY metric ORDER BY "timestamp" DESC) AS row_num


### PR DESCRIPTION
This pull request includes changes to the `scripts/check_perf_results.sql` file to add default values for several parameters if they are not provided. The changes ensure that the script can run with predefined defaults, enhancing its robustness and usability.

Enhancements to parameter handling:

* Added default value for `platform` parameter, setting it to 'Windows 2019' if not provided.
* Added default value for `max_sigma` parameter, setting it to '2' if not provided.
* Added default value for `look_back` parameter, setting it to '30 days' if not provided.
* Added default value for `repository` parameter, setting it to 'microsoft/ebpf-for-windows' if not provided.