### PR TITLE
Install WDK

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         configuration: [ 'Release' ]
-        platform: [ 'windows-2019', 'windows-2022', 'ubuntu-22.04' ]
+        platform: [ 'windows-2022', 'ubuntu-22.04' ]
         option: [ none, jit ]
         exclude:
           - platform: windows-2019

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         configuration: [ 'Release', 'Debug' ]
         option: [ none, sanitizer, coverage ]
-        platform: [ 'ubuntu-22.04', 'windows-2019' ]
+        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
         exclude:
           - platform: windows-2019
             option: sanitizer

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         configuration: [ 'Release', 'Debug' ]
         option: [ none, sanitizer, coverage ]
-        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
+        platform: [ 'ubuntu-22.04', 'windows-2022' ]
         exclude:
           - platform: windows-2019
             option: sanitizer

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -72,7 +72,7 @@ jobs:
       if: inputs.platform == 'windows-2019' || inputs.platform == 'windows-2022'
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
-        name: "build-${{inputs.Configuration}}-windows-2019-none"
+        name: "build-${{inputs.Configuration}}-${{inputs.platform}}-none"
         path: ${{github.workspace}}/build/bin
 
     - name: Download BPF Performance tests - Ubuntu-22.04

--- a/bpf/CMakeLists.txt
+++ b/bpf/CMakeLists.txt
@@ -5,6 +5,23 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
+if (PLATFORM_WINDOWS)
+  set(NUGET_PACKAGES
+  "Microsoft.Windows.SDK.CPP"
+  "Microsoft.Windows.SDK.CPP.x64"
+  "Microsoft.Windows.WDK.x64"
+  )
+
+  find_program(NUGET nuget)
+  if(NOT NUGET)
+    message("ERROR: You must first install nuget.exe from https://www.nuget.org/downloads")
+  else()
+    foreach(PACKAGE ${NUGET_PACKAGES})
+      execute_process(COMMAND ${NUGET} install ${PACKAGE} -OutputDirectory ${PROJECT_BINARY_DIR}/packages)
+    endforeach()
+  endif()
+endif()
+
 # Each test consists of a C file, an output file name, and an optional option-list, seperated by commas.
 set(test_cases
     "baseline,baseline,-DBPF"
@@ -107,7 +124,7 @@ function(convert_to_native file_name out_name option_list)
     # Run the powershell script to convert the .o file to a .sys file
     add_custom_command(
         OUTPUT ${bpf_sys_file_path} ${bpf_pdb_file_path}
-        COMMAND powershell -ExecutionPolicy Bypass -File ${EBPF_BIN_PATH}/Convert-BpfToNative.ps1 -FileName ${bpf_obj_file_name} -IncludeDir ${EBPF_INC_PATH} -OutDir ${CMAKE_CURRENT_BINARY_DIR} -BinDir ${EBPF_BIN_PATH} -Configuration $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>
+        COMMAND powershell -ExecutionPolicy Bypass -File ${EBPF_BIN_PATH}/Convert-BpfToNative.ps1 -FileName ${bpf_obj_file_name} -IncludeDir ${EBPF_INC_PATH} -OutDir ${CMAKE_CURRENT_BINARY_DIR} -BinDir ${EBPF_BIN_PATH} -Configuration $<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release> -Packages ${CMAKE_BINARY_DIR}/packages
         DEPENDS ${bpf_obj_file_path}
         COMMENT "Converting BPF object ${bpf_obj_file_path} to native"
         POST_BUILD


### PR DESCRIPTION
This pull request includes changes to support downloading and installing Windows Driver Kit (WDK) packages for Windows platforms in the build process. The changes involve updates to the GitHub Actions workflow and the CMake configuration.

### Build process improvements:

* [`.github/workflows/Build.yml`](diffhunk://#diff-33612a4f71286f3a6658f13c4f2f1947085f3686fa78e2090306cce1c0a6ffbcR67-R74): Added steps to download WDK packages when the platform is either `windows-2019` or `windows-2022`.

* [`bpf/CMakeLists.txt`](diffhunk://#diff-19b5a8db8b8f944d204fa9873a1ac4141caca94d6894e1d59460f08bcb002e44R8-R24): Updated the CMake configuration to include logic for downloading and installing necessary NuGet packages for Windows platforms, ensuring the required packages are available during the build process.