### PR TITLE
Remove upload ws2019

### DIFF
--- a/.github/workflows/UploadPerfResults.yml
+++ b/.github/workflows/UploadPerfResults.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write  # for azure/login to get credentials from GitHub OIDC provider
     strategy:
       matrix:
-        platform: [ 'ubuntu-22.04', 'windows-2019', 'windows-2022' ]
+        platform: [ 'ubuntu-22.04', 'windows-2022' ]
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/UploadPerfResults.yml` file. The change updates the matrix of platforms by removing 'windows-2019' and retaining 'ubuntu-22.04' and 'windows-2022'.

* [`.github/workflows/UploadPerfResults.yml`](diffhunk://#diff-c89000e19beb4c24f547ea54db6d5ecd603f686733c56775e481a2c3853a2caeL28-R28): Removed 'windows-2019' from the platform matrix.